### PR TITLE
fix: jwk modulus encoding

### DIFF
--- a/internal/jwks/jwks.go
+++ b/internal/jwks/jwks.go
@@ -58,7 +58,7 @@ func NewJWK(rsaPublicKey string) (*JWK, error) {
 	jwk := JWK{
 		Alg: "RS256",
 		Kty: "RSA",
-		N:   base64.RawStdEncoding.EncodeToString(publicKey.N.Bytes()),
+		N:   base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes()),
 		E:   "AQAB",
 	}
 


### PR DESCRIPTION
The modulus `n` was not encoded correctly which caused JWK validation errors.